### PR TITLE
Add support for querying SauceLabs for capacity

### DIFF
--- a/amplium/api/proxy.py
+++ b/amplium/api/proxy.py
@@ -91,7 +91,10 @@ def _get_base_url(new_session):
         if key[0].endswith('Capabilities'):
             # If saucelabs is not used, use zookeeper to find the url
             if saucelabs_handler.is_saucelabs_requested(new_session, key[0]):
-                return saucelabs_handler.get_sauce_url()
+                return retry(
+                    func=saucelabs_handler.get_sauce_url,
+                    max_time=CONFIG.session_queue_time
+                )
 
     ip_address = retry(
         func=_get_ip_address,

--- a/amplium/utils/saucelabs_handler.py
+++ b/amplium/utils/saucelabs_handler.py
@@ -1,10 +1,13 @@
 """Handles the SauceLabs Configurations"""
 import logging
 
+from requests import Session
+
 from amplium import CONFIG
-from amplium.api.exceptions import IntegrationNotConfigured
+from amplium.api.exceptions import IntegrationNotConfigured, NoAvailableCapacityException, AmpliumException
 
 logger = logging.getLogger(__name__)
+session = Session()
 
 
 def get_sauce_url():
@@ -13,11 +16,15 @@ def get_sauce_url():
     saucelabs_config = CONFIG.integrations.get('saucelabs')
 
     if not saucelabs_config:
-        raise IntegrationNotConfigured("Attempted to use Saucelabs, but Saucelabs is not configured.")
+        raise IntegrationNotConfigured("Attempted to use SauceLabs, but SauceLabs is not configured.")
 
     username = saucelabs_config['username']
     access_key = saucelabs_config['accesskey']
-    return 'https://{0}:{1}@ondemand.saucelabs.com:443'.format(username, access_key)
+
+    if is_saucelabs_available():
+        return 'https://{0}:{1}@ondemand.saucelabs.com:443'.format(username, access_key)
+    else:
+        raise NoAvailableCapacityException("SauceLabs has no available capacity.")
 
 
 def is_saucelabs_requested(session_data, capability_type):
@@ -25,3 +32,43 @@ def is_saucelabs_requested(session_data, capability_type):
     if 'amplium:useSauceLabs' in session_data[capability_type]:
         return session_data[capability_type]['amplium:useSauceLabs']
     return False
+
+
+def is_saucelabs_available():
+    """
+    Convenience function for checking whether SauceLabs has available capacity.
+    :return: True if SauceLabs has available capacity, false otherwise.
+    """
+    saucelabs_config = CONFIG.integrations.get('saucelabs')
+    username = saucelabs_config['username']
+    access_key = saucelabs_config['accesskey']
+    session.auth = (username, access_key)
+
+    response = session.get(
+        "https://saucelabs.com/rest/v1.1/users/{username}/concurrency".format(username=username)
+    )
+
+    if response.status_code == 401:
+        raise AmpliumException(
+            message="SauceLabs integration is not correctly configured: Invalid credentials",
+            error="AMPLIUM_SAUCELABS_CREDENTIALS_BAD",
+            status_code=500
+        )
+    elif response.status_code != 200:
+        raise AmpliumException(
+            message="Error communicating with SauceLabs",
+            error="AMPLIUM_SAUCELABS_ERROR",
+            status_code=500
+        )
+
+    response_json = response.json()
+
+    limits = response_json["concurrency"]["ancestor"]["allowed"]
+    usages = response_json["concurrency"]["ancestor"]["current"]
+
+    limit = limits.get("mac") or limits.get("real_device", 0)
+    usage = usages.get("mac") or usages.get("real_device", 0)
+
+    print limit, usage
+
+    return bool(limit - usage)

--- a/amplium/utils/saucelabs_handler.py
+++ b/amplium/utils/saucelabs_handler.py
@@ -69,6 +69,4 @@ def is_saucelabs_available():
     limit = limits.get("mac") or limits.get("real_device", 0)
     usage = usages.get("mac") or usages.get("real_device", 0)
 
-    print limit, usage
-
     return bool(limit - usage)

--- a/amplium/version.py
+++ b/amplium/version.py
@@ -1,6 +1,6 @@
 """Place of record for the package version"""
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __build__ = "dev1"  # will be updated by egg build
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test-requirements.pip
+++ b/test-requirements.pip
@@ -9,3 +9,4 @@ mock>=1.0.1,<2
 coverage>=3.5.2,<4
 # Additional libraries
 moto>=0.4.31,<1
+requests-mock>=1.3.0,<2

--- a/test/unit/sauce_test.py
+++ b/test/unit/sauce_test.py
@@ -2,18 +2,27 @@
 
 import unittest
 
-from amplium.api.exceptions import IntegrationNotConfigured
+import requests_mock
+
+from mock import patch, MagicMock
+
+from amplium.api.exceptions import IntegrationNotConfigured, AmpliumException, NoAvailableCapacityException
 from amplium.utils import saucelabs_handler
-from mock import patch
 
 
 class SauceUnitTests(unittest.TestCase):
     """Unit tests for the sauce handler"""
 
+    @patch('amplium.utils.saucelabs_handler.is_saucelabs_available', MagicMock(return_value=True))
     def test_success_get_sauce(self):
         """Tests if get sauce url returns a url"""
         response = saucelabs_handler.get_sauce_url()
         self.assertEqual(response, 'https://username:accesskey@ondemand.saucelabs.com:443')
+
+    @patch('amplium.utils.saucelabs_handler.is_saucelabs_available', MagicMock(return_value=False))
+    def test_fail_get_sauce(self):
+        """Tests if SauceLabs is not available get exception"""
+        self.assertRaises(NoAvailableCapacityException, saucelabs_handler.get_sauce_url)
 
     @patch('amplium.utils.saucelabs_handler.CONFIG')
     def test_none_get_sauce(self, mock_config):
@@ -22,7 +31,7 @@ class SauceUnitTests(unittest.TestCase):
         self.assertRaises(IntegrationNotConfigured, saucelabs_handler.get_sauce_url)
 
     def test_is_saucelabs_requested(self):
-        """Tests if the is saucelabs requested is true"""
+        """Tests if the is SauceLabs requested is true"""
         test_session_data = {'Capabilities': {
             'amplium:useSauceLabs': True
         }}
@@ -30,7 +39,76 @@ class SauceUnitTests(unittest.TestCase):
         self.assertEqual(response, True)
 
     def test_is_not_saucelabs_requested(self):
-        """Tests if the is saucelabs requested is true"""
+        """Tests if the is SauceLabs requested is true"""
         test_session_data = {'Capabilities': {}}
         response = saucelabs_handler.is_saucelabs_requested(test_session_data, 'Capabilities')
         self.assertEqual(response, False)
+
+    @requests_mock.Mocker()
+    def test_saucelabs_available_happy(self, mock_requests):
+        """Tests if SauceLabs is available with happy response"""
+        mock_response = {
+            "concurrency": {
+                "ancestor": {
+                    "allowed": {
+                        "mac": 100,
+                        "real_device": 30,
+                        "manual": 100,
+                        "overall": 100
+                    },
+                    "username": "FAKE_NAME",
+                    "current": {
+                        "overall": 0,
+                        "mac": 0,
+                        "manual": 0
+                    }
+                }
+            }
+        }
+
+        mock_requests.get(requests_mock.ANY, json=mock_response)
+
+        response = saucelabs_handler.is_saucelabs_available()
+
+        self.assertTrue(response)
+
+    @requests_mock.Mocker()
+    def test_saucelabs_available_busy(self, mock_requests):
+        """Tests if SauceLabs is available with busy response"""
+        mock_response = {
+            "concurrency": {
+                "ancestor": {
+                    "allowed": {
+                        "mac": 100,
+                        "real_device": 30,
+                        "manual": 100,
+                        "overall": 100
+                    },
+                    "username": "FAKE_NAME",
+                    "current": {
+                        "overall": 100,
+                        "mac": 100,
+                        "manual": 100
+                    }
+                }
+            }
+        }
+        mock_requests.get(requests_mock.ANY, json=mock_response)
+
+        response = saucelabs_handler.is_saucelabs_available()
+
+        self.assertFalse(response)
+
+    @requests_mock.Mocker()
+    def test_saucelabs_available_unauthorized(self, mock_requests):
+        """Tests if SauceLabs is available with unauthorized response"""
+        mock_requests.get(requests_mock.ANY, status_code=401, json={})
+
+        self.assertRaises(AmpliumException, saucelabs_handler.is_saucelabs_available)
+
+    @requests_mock.Mocker()
+    def test_saucelabs_available_error(self, mock_requests):
+        """Tests if SauceLabs is available with error response"""
+        mock_requests.get(requests_mock.ANY, status_code=500, json={})
+
+        self.assertRaises(AmpliumException, saucelabs_handler.is_saucelabs_available)


### PR DESCRIPTION
Similar to how we query Selenium Grids to find out if they have
available capacity before sending sessions to them, let's do the same
for SauceLabs.

Added a new function to the SauceLabs handler for querying the
concurrency endpoint of the SauceLabs API. This function returns True if
there is available capacity, False otherwise. This function is then
called before we construct the SauceLabs URL for the test. Similar to
how we keep trying to send a session to the Selenium Grid until the
timeout is reached, we keep checking SauceLabs for available capacity
until the timeout is exceeded. Both of these timeouts are currently
controlled by the same configuration option.

Additionally, added unit tests covering the new feature. Introduced
`requests_mock` as a new test dependency to make testing against the
SauceLabs API a less annoying task.