### PR TITLE
TEI-1393 Zookeeper Errors

### DIFF
--- a/amplium/utils/zookeeper.py
+++ b/amplium/utils/zookeeper.py
@@ -17,6 +17,7 @@ class ZookeeperGridNodeStatus(object):
         port = port
         zookeeper_host = "%s:%s" % (host, port)
         self.zookeeper = KazooClient(hosts=zookeeper_host, read_only=True)
+        self.zookeeper.start()
         self.nerve_directory = nerve_directory
 
     def get_nodes(self):
@@ -27,12 +28,8 @@ class ZookeeperGridNodeStatus(object):
             array:   Returns an array with all the nodes with their data
         """
         try:
-            self.zookeeper.start()
-
             children = self.zookeeper.get_children(self.nerve_directory)
             ip_addresses = [self.get_grid_node_data(child) for child in children]
-
-            self.zookeeper.stop()
 
             return ip_addresses
         except KazooTimeoutError:

--- a/amplium/utils/zookeeper.py
+++ b/amplium/utils/zookeeper.py
@@ -1,10 +1,10 @@
 """Used for calling ZookeeperGridNodeStatus"""
-
 import ast
 import logging
 
 from kazoo.client import KazooClient
-from kazoo.handlers.threading import KazooTimeoutError
+from kazoo.exceptions import KazooException
+
 
 logger = logging.getLogger(__name__)
 
@@ -28,17 +28,17 @@ class ZookeeperGridNodeStatus(object):
             array:   Returns an array with all the nodes with their data
         """
         try:
-            children = self.zookeeper.get_children(self.nerve_directory)
+            children = self.zookeeper.retry(self.zookeeper.get_children, self.nerve_directory)
             ip_addresses = [self.get_grid_node_data(child) for child in children]
 
             return ip_addresses
-        except KazooTimeoutError:
-            logger.exception("Zookeeper Timeout Error:")
+        except KazooException:
+            logger.exception("Unable to connect to zookeeper")
             return []
 
     def get_grid_node_data(self, grid_node):
         """Gets host, port, and name from the grid node"""
         child_directory = "{0}/{1}".format(self.nerve_directory, grid_node)
-        child_data = self.zookeeper.get(child_directory)
+        child_data = self.zookeeper.retry(self.zookeeper.get, child_directory)
         # Gets host, port, and name
         return ast.literal_eval(child_data[0])


### PR DESCRIPTION
We were constantly recreating the zookeeper client because this was originally a Lambda. Now that it's a hostclass, we don't have to do such nonsense.

Also added retrying to the zookeeper calls, as recommended by the Kazoo docs.