### PR TITLE
Handle Zookeeper Nodes Disappearing Bug

### DIFF
--- a/amplium/utils/grid_handler.py
+++ b/amplium/utils/grid_handler.py
@@ -6,6 +6,8 @@ import re
 import logging
 from collections import defaultdict, Counter
 
+from requests import ConnectionError
+
 from amplium.api.exceptions import NoAvailableGridsException, NoAvailableCapacityException
 from amplium.utils.utils import retry
 
@@ -160,17 +162,22 @@ class GridHandler(object):
             host_data = {'host': node['host'], 'port': node['port']}
             node_ip = self._format_url(node['host'], node['port'])
 
-            # Gets the browser usage
-            browsers = self.get_usage_per_browser_type(node_ip)
-            host_data['browsers'] = browsers['breakdown']
+            try:
+                # Gets the browser usage
+                browsers = self.get_usage_per_browser_type(node_ip)
+                host_data['browsers'] = browsers['breakdown']
 
-            # Gets the total capacity
-            host_data['total_capacity'] = self.get_grid_hub_sessions_capacity(node_ip)
-            host_data['available_capacity'] = host_data['total_capacity'] - browsers['total']
+                # Gets the total capacity
+                host_data['total_capacity'] = self.get_grid_hub_sessions_capacity(node_ip)
+                host_data['available_capacity'] = host_data['total_capacity'] - browsers['total']
 
-            # Gets the queue
-            response = self.session.get(node_ip + "/grid/api/hub").json()
-            host_data['queue'] = response['newSessionRequestCount']
+                # Gets the queue
+                response = self.session.get(node_ip + "/grid/api/hub").json()
+                host_data['queue'] = response['newSessionRequestCount']
+            except ConnectionError:
+                self.zookeeper.get_nodes()
+                continue
+
             data.append(host_data)
 
         return data

--- a/amplium/utils/grid_handler.py
+++ b/amplium/utils/grid_handler.py
@@ -6,7 +6,7 @@ import re
 import logging
 from collections import defaultdict, Counter
 
-from requests import ConnectionError
+from requests.exceptions import RequestException
 
 from amplium.api.exceptions import NoAvailableGridsException, NoAvailableCapacityException
 from amplium.utils.utils import retry
@@ -174,7 +174,7 @@ class GridHandler(object):
                 # Gets the queue
                 response = self.session.get(node_ip + "/grid/api/hub").json()
                 host_data['queue'] = response['newSessionRequestCount']
-            except ConnectionError:
+            except RequestException:
                 self.zookeeper.get_nodes()
                 continue
 

--- a/amplium/utils/zookeeper.py
+++ b/amplium/utils/zookeeper.py
@@ -27,13 +27,16 @@ class ZookeeperGridNodeStatus(object):
         self.zookeeper.start()
         ChildrenWatch(self.zookeeper, self.nerve_directory, self.get_nodes)
 
-    def get_nodes(self, children):
+    def get_nodes(self, children=None):
         """
         Gets the data for the grid nodes.
-        :param children: A list of Zookeeper nodes to lookup.
+        :param children: A list of Zookeeper nodes to lookup. If None, children will be looked up.
         :return: A list of tuples containing host, port, and name of each grid node.
         """
         try:
+            if children is None:
+                children = self.zookeeper.retry(self.zookeeper.get_children, self.nerve_directory)
+
             self.nodes = [self.get_grid_node_data(child) for child in children]
         except KazooException:
             logger.exception("Unable to connect to zookeeper")

--- a/amplium/version.py
+++ b/amplium/version.py
@@ -1,6 +1,6 @@
 """Place of record for the package version"""
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __build__ = "dev1"  # will be updated by egg build
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Apparently, it was possible for some kind of bad state to develop where
the Zookeeper helper's list of nodes would contain an old node that no
longer exists but the watcher wouldn't be called to update it. Now if we
encounter that situation, we can catch the error and turn around and
forcibly update the list of nodes.