### PR TITLE
Add Connection Retry Policy

### DIFF
--- a/amplium/utils/zookeeper.py
+++ b/amplium/utils/zookeeper.py
@@ -5,6 +5,7 @@ import logging
 from kazoo.client import KazooClient
 from kazoo.exceptions import KazooException
 from kazoo.recipe.watchers import ChildrenWatch
+from kazoo.retry import KazooRetry
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +17,8 @@ class ZookeeperGridNodeStatus(object):
         host = host
         port = port
         zookeeper_host = "%s:%s" % (host, port)
-        self.zookeeper = KazooClient(hosts=zookeeper_host, read_only=True)
+        connection_retry = KazooRetry(max_tries=10)
+        self.zookeeper = KazooClient(hosts=zookeeper_host, read_only=True, connection_retry=connection_retry)
         self.nerve_directory = nerve_directory
         self.nodes = []
 

--- a/amplium/version.py
+++ b/amplium/version.py
@@ -1,6 +1,6 @@
 """Place of record for the package version"""
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __build__ = "dev1"  # will be updated by egg build
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
The default settings make it so that Amplium continually retries
connections to Zookeeper. This means that sometimes Amplium can get
stuck into an infinite loop where it continually tries to connect to
Zookeeper. Adding this policy so that we have an upper bound of retries,
and the process will die and Apache will bring it back if we end up in
some strange state.