### PR TITLE
Return 503 if no selenium grids

### DIFF
--- a/amplium/api/internal.py
+++ b/amplium/api/internal.py
@@ -10,4 +10,5 @@ def get_status():
     """Handler for the status path"""
     data = GRID_HANDLER.get_grid_info()
     data_packet = {"status": "OK", "nodes": data}
-    return data_packet
+    status_code = 200 if data else 503
+    return data_packet, status_code

--- a/amplium/version.py
+++ b/amplium/version.py
@@ -1,6 +1,6 @@
 """Place of record for the package version"""
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __build__ = "dev1"  # will be updated by egg build
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/internal_test.py
+++ b/test/unit/internal_test.py
@@ -9,8 +9,16 @@ from amplium.api import internal
 class InternalUnitTests(unittest.TestCase):
     """Tests the internal.py"""
 
-    @patch('amplium.ZOOKEEPER.get_nodes', MagicMock(return_value={}))
+    @patch('amplium.GRID_HANDLER.get_grid_info', MagicMock(return_value={"some": "data"}))
     def test_get_status(self):
         """Tests the get status function"""
-        result = internal.get_status()
+        result, code = internal.get_status()
         self.assertEqual(result['status'], 'OK')
+        self.assertEqual(code, 200)
+
+    @patch('amplium.GRID_HANDLER.get_grid_info', MagicMock(return_value={}))
+    def test_get_status_without_data(self):
+        """Tests the get status function"""
+        result, code = internal.get_status()
+        self.assertEqual(result['status'], 'OK')
+        self.assertEqual(code, 503)


### PR DESCRIPTION
Change the status page to return a 503 error if there are no grids
connected to amplium, indicating that the service is not able to field
requests.