### PR TITLE
Fix Datadog Error Handler

### DIFF
--- a/amplium/utils/datadog_handler.py
+++ b/amplium/utils/datadog_handler.py
@@ -45,5 +45,5 @@ class DatadogHandler(object):
             )
         except ApiNotInitialized:
             logger.debug("Attempted to send Datadog metric, but Datadog is not initialized.", exc_info=True)
-        except (ClientError, HttpBackoff, HTTPError, HttpTimeout, ApiError):
+        except (ClientError, HttpBackoff, HTTPError, HttpTimeout, ApiError, ValueError):
             logger.warning("Datadog encountered an error", exc_info=True)

--- a/amplium/version.py
+++ b/amplium/version.py
@@ -1,6 +1,6 @@
 """Place of record for the package version"""
 
-__version__ = "0.7.4"
+__version__ = "0.7.5"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __build__ = "dev1"  # will be updated by egg build
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Updating Datadog logging handler to make sure that we handle ValueErrors
as well. This can occur when the Datadog API does not return a JSON
object, which occurs when the supplied credentials are invalid.