### PR TITLE
Catch ConnectionErrors

### DIFF
--- a/amplium/api/proxy.py
+++ b/amplium/api/proxy.py
@@ -62,11 +62,9 @@ def send_request(method, session_id=None, command=None, data=None, url=None):
         response = SESSION.request(method=method, url=url, json=data)
         logger.info("%s | Received from (%s) with response: %s", session_id, url, response.text)
         return response.json()
-    except requests.HTTPError as error:
-        logger.exception("Http Error: ")
-        return {'status': error.response.status_code, 'message': 'Http error occurred while proxying'},\
+    except (requests.HTTPError, requests.Timeout, requests.ConnectionError) as error:
+        logger.exception("Error while handling request")
+        return (
+            {'status': error.response.status_code, 'message': 'Error occurred while proxying'},
             error.response.status_code
-    except requests.Timeout as error:
-        logger.exception("Timeout Exception: ")
-        return {'status': error.response.status_code, 'message': 'Timeout occurred while proxying'},\
-            error.response.status_code
+        )

--- a/amplium/version.py
+++ b/amplium/version.py
@@ -1,6 +1,6 @@
 """Place of record for the package version"""
 
-__version__ = "0.7.5"
+__version__ = "0.7.6"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __build__ = "dev1"  # will be updated by egg build
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/proxy_test.py
+++ b/test/unit/proxy_test.py
@@ -161,15 +161,4 @@ class ProxyUnitTests(unittest.TestCase):
         """Tests the request wrapper's timeout exceptions"""
         mock_session.request.side_effect = requests.exceptions.Timeout(response=MagicMock(status_code=408))
         response = proxy.send_request(method='POST', data={'data': 'test'})
-        self.assertEqual(response[0]['message'], 'Timeout occurred while proxying')
-
-    @patch(
-        'amplium.api.proxy.GRID_HANDLER.unroll_session_id',
-        MagicMock(return_value=("test_session_id", "http://test_host_1:1234"))
-    )
-    @patch('amplium.api.proxy.SESSION')
-    def test_request_wrapper_httperror(self, mock_session):
-        """Tests the httperror exception"""
-        mock_session.request.side_effect = requests.exceptions.HTTPError(response=MagicMock(status_code=404))
-        response = proxy.send_request(method='POST', data={'data': 'test'})
-        self.assertEqual(response[0]['message'], 'Http error occurred while proxying')
+        self.assertEqual(response[0]['status'], 408)


### PR DESCRIPTION
It's possible for us to get more than HTTP Errors and Timeout Errors
here, so let's also catch Connection Errors.