### PR TITLE
BugFix: Restrict Version of Werkzeug

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -7,3 +7,4 @@ kazoo>=2.2.1,<3
 boto3>=1.4.4,<2
 pathlib>=1.0.1,<2
 datadog>=0.16.0,<1
+Werkzeug>=0.16.1,<1


### PR DESCRIPTION
Looks like this was pulling in version 1.0, which doesn't work with
Python 2.